### PR TITLE
Handle shift + n keybind conflict

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -53,7 +53,7 @@
   {
     "key": "shift+n",
     "command": "workbench.action.newWindow",
-    "when": "!explorerViewletFocus"
+    "when": "!explorerViewletFocus && vim.mode != 'Insert'"
   },
   {
     "command": "deleteFile",


### PR DESCRIPTION
Hey 👋 

I ran into issues with my own keybinds where shift+n kept opening a new vscode window whenever I wanted to make a new factory method (func NewSomething...) 

I'm curious if noone has run into this issue before? I feel like it would be something someone run into fast. So maybe you don't have this issue? Maybe it's a setting on my end that breaks this? Let me know.

I fixed it on my end by disgarding the command if we are in Insert mode. However, that means that I'm hard coupling my keybinds.json with the Vim plugin (but I guess that violation is already thought into the keybinds.json?)

Let me know what you think and if you can use this :) Cheers.