### PR TITLE
remove cmd+q default binding to prevent closing window by mistake

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -52,7 +52,7 @@
   },
   {
     "key": "shift+n",
-    "command": "workbench.action.newWindow",
+    "command": "",
     "when": "!explorerViewletFocus"
   },
   {
@@ -70,6 +70,7 @@
     "key": "ctrl+z",
     "command": "workbench.action.toggleZenMode"
   },
+  // MAC OS EXTRA
   {
     "key": "cmd+q",
     "command": ""

--- a/keybindings.json
+++ b/keybindings.json
@@ -69,5 +69,9 @@
   {
     "key": "ctrl+z",
     "command": "workbench.action.toggleZenMode"
+  },
+  {
+    "key": "cmd+q",
+    "command": ""
   }
 ]

--- a/settings.json
+++ b/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.formatOnSave": true,
   "editor.suggest.insertMode": "replace",
-  "terminal.integrated.fontFamily": "MesloLGS NF",
+  "terminal.integrated.fontFamily": "ubuntu",
   "editor.linkedEditing": true,
   "javascript.updateImportsOnFileMove.enabled": "always",
   "window.zoomLevel": 0.5,
@@ -9,14 +9,10 @@
   "[json]": {},
   "workbench.statusBar.visible": false,
   "editor.minimap.enabled": false,
-  "breadcrumbs.enabled": false,
-  "workbench.iconTheme": "material-icon-theme",
   "update.showReleaseNotes": false,
-  "workbench.activityBar.visible": false,
   "zenMode.hideLineNumbers": false,
-  "zenMode.hideTabs": false,
   "editor.lineNumbers": "relative",
-
+  "editor.cursorSurroundingLines": 999,
   "vim.leader": "<Space>",
   "vim.hlsearch": true,
   "vim.normalModeKeyBindingsNonRecursive": [
@@ -88,5 +84,7 @@
   },
   "[jsonc]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "workbench.activityBar.location": "hidden",
+  "redhat.telemetry.enabled": true
 }

--- a/settings.json
+++ b/settings.json
@@ -1,18 +1,16 @@
 {
   "editor.formatOnSave": true,
   "editor.suggest.insertMode": "replace",
-  "terminal.integrated.fontFamily": "ubuntu",
   "editor.linkedEditing": true,
   "javascript.updateImportsOnFileMove.enabled": "always",
-  "window.zoomLevel": 0.5,
   "launch": {},
   "[json]": {},
-  "workbench.statusBar.visible": false,
   "editor.minimap.enabled": false,
   "update.showReleaseNotes": false,
   "zenMode.hideLineNumbers": false,
   "editor.lineNumbers": "relative",
   "editor.cursorSurroundingLines": 999,
+  "window.zoomLevel": 0.5,
   "vim.leader": "<Space>",
   "vim.hlsearch": true,
   "vim.normalModeKeyBindingsNonRecursive": [
@@ -86,5 +84,8 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "workbench.activityBar.location": "hidden",
-  "redhat.telemetry.enabled": true
+  "redhat.telemetry.enabled": true,
+  "editor.cursorBlinking": "phase",
+  "editor.fontFamily": "'BlexMono Nerd Font', Consolas, 'Courier New', monospace",
+  "workbench.colorTheme": "Rosé Pine Burnt"
 }


### PR DESCRIPTION
Remove cmd + q so we don't close vscode by mistake