### PR TITLE
Update keybindings.json

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -48,7 +48,7 @@
   {
     "key": "shift+n",
     "command": "explorer.newFolder",
-    "when": "explorerViewletFocus"
+    "when": "explorerViewletFocus && !inputFocus"
   },
   {
     "key": "shift+n",


### PR DESCRIPTION
added !inputFocus in shift+n keybinding otherwise you cant name a file with capital N , it switches to creating a folder