### PR TITLE
file tree optimized

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -31,9 +31,9 @@
     "key": "ctrl+e"
   },
   {
-    "command": "workbench.files.action.focusFilesExplorer",
+    "command": "workbench.view.explorer",
     "key": "ctrl+e",
-    "when": "editorTextFocus"
+    "when": "!sideBarVisible"
   },
   {
     "key": "n",


### PR DESCRIPTION
toggling file explorer optimized 
earlier if no text file was open in vscode, one cannot toggle the file explorer. also if a vscode page i.e. settings, keybinding is open in UI mode  then file explorer will not open. this was because editorTextFocus boolean were false in such cases. replaced it with better command which works in all conditions.